### PR TITLE
Emscripten now emits WASM by default, so disable it for the asm.js build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ services:
 - docker
 before_install:
 # set up a docker image with emscripten ready to go
-- docker run -dit --name emscripten -v $(pwd):/project trzeci/emscripten:sdk-incoming-64bit bash
+- docker run -dit --name emscripten -v $(pwd):/project trzeci/emscripten:latest bash
 script:
 # install the library dependencies
 - ./ci-install.sh

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ BASE_ARGS="--bind -O3 --pre-js src/prefix.js --post-js src/postfix.js --llvm-lto
   -s NO_FILESYSTEM=1 -I$GEO_PATH/include/"
 GEO_ARGS=""
 SRC_ARGS="src/bindings.cpp $GEO_PATH/src/*.cpp"
-ASM_ARGS="--closure 0 -o dist/os-asm.js"
+ASM_ARGS="-s WASM=0 --closure 0 -o dist/os-asm.js"
 WASM_ARGS="-s WASM=1 -o dist/os-wasm.js"
 
 if [[ -d "tools" ]]; then


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/pull/6419.