### PR TITLE
chore(install): use git for emsdk

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -14,7 +14,7 @@ echo "Set up emscripten sdk"
 pushd tools/emsdk-portable
 git pull
 ./emsdk install latest
-./emsdk activate latest
+./emsdk activate --embedded latest
 popd
 
 ./ci-install.sh


### PR DESCRIPTION
The `emsdk` version installed via the portable download may be out of date. Instead, just install `emsdk` as recommended by emscripten's documentation.