### PR TITLE
feat: add node support and meridian intersection support

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -15,18 +15,65 @@ struct Coord {
   double lat;
 };
 
+
+// meridian intersection
+void normalizeLon(double& lon, double& center) {
+  double i = center - 180;
+  double j = center + 180;
+  while (lon < i) lon += 360;
+  while (lon > j) lon -= 360;
+}
+
+void ensureArgOrder(Coord& p1, Coord& p2, double& meridian) {
+  normalizeLon(p1.lon, meridian);
+  normalizeLon(p2.lon, meridian);
+
+  if (p2.lon < p1.lon) {
+    Coord swp = p1;
+    p1 = p2;
+    p2 = swp;
+  }
+};
+
+Coord meridianIntersection_(Coord p1, Coord p2, double meridian, double s12,
+    const std::function<void(double s12, double& lat, double& lon)>& position) {
+  double left = 0;
+  double right = s12;
+  double middle;
+  double lat, lon = p1.lon;
+  double lastLon = lon;
+
+  while (left < right && abs(meridian - lon) > 1E-8) {
+    middle = (left + right) * 0.5;
+    position(middle, lat, lon);
+    normalizeLon(lon, meridian);
+
+    if (abs(lon - lastLon) < 1E-9) {
+      break;
+    }
+
+    if (meridian < lon) {
+      right = middle;
+    } else if (meridian > lon) {
+      left = middle;
+    } else {
+      break;
+    }
+
+    lastLon = lon;
+  }
+
+  return Coord {lon, lat};
+}
+
+
+// Geodesic
 struct GeodesicDirectResult {
   double distance;
   double initialBearing;
   double finalBearing;
 };
 
-struct RhumbDirectResult {
-  double distance;
-  double bearing;
-};
-
-// Geodesic
 GeodesicDirectResult geodesicInverse(Coord p1, Coord p2) {
   const Geodesic& geodesic = Geodesic::WGS84();
   double s12, azi1, azi2;
@@ -44,10 +91,10 @@ Coord geodesicDirect(Coord p1, double azi1, double s12) {
 void geodesicInterpolate_(Coord p1, Coord p2, double * flatCoords, int numPoints) {
   const Geodesic& geodesic = Geodesic::WGS84();
   const GeodesicLine line = geodesic.InverseLine(p1.lat, p1.lon, p2.lat, p2.lon);
-  double da = line.Arc() / (numPoints - 1);
+  double da = line.Distance() / (numPoints - 1);
 
   for (int i = 0; i < numPoints; i++) {
-    line.ArcPosition(i * da, flatCoords[2 * i + 1], flatCoords[2 * i]);
+    line.Position(i * da, flatCoords[2 * i + 1], flatCoords[2 * i]);
   }
 }
 
@@ -55,7 +102,23 @@ void geodesicInterpolate(Coord p1, Coord p2, intptr_t ptr, int numPoints) {
   geodesicInterpolate_(p1, p2, reinterpret_cast<double *>(ptr), numPoints);
 }
 
+Coord geodesicMeridianIntersection(Coord p1, Coord p2, double meridian) {
+  ensureArgOrder(p1, p2, meridian);
+  const Geodesic& geodesic = Geodesic::WGS84();
+  const GeodesicLine line = geodesic.InverseLine(p1.lat, p1.lon, p2.lat, p2.lon);
+  return meridianIntersection_(p1, p2, meridian, line.Distance(),
+      [line](double s12, double& lat, double& lon) {
+        line.Position(s12, lat, lon);
+      });
+}
+
+
 // Rhumb
+struct RhumbDirectResult {
+  double distance;
+  double bearing;
+};
+
 RhumbDirectResult rhumbInverse(Coord p1, Coord p2) {
   const Rhumb& rhumb = Rhumb::WGS84();
   double s12, azi1;
@@ -70,23 +133,38 @@ Coord rhumbDirect(Coord p1, double azi1, double s12) {
   return Coord {lon2, lat2};
 }
 
-void rhumbInterpolate_(Coord p1, Coord p2, double * flatCoords, int numPoints) {
+RhumbLine getInverseRhumbLine(Coord p1, Coord p2, double& s12) {
   const Rhumb& rhumb = Rhumb::WGS84();
-  double azi1, s12;
+  double azi1;
   rhumb.Inverse(p1.lat, p1.lon, p2.lat, p2.lon, s12, azi1);
-  const RhumbLine line = rhumb.Line(p1.lat, p1.lon, azi1);
+  return rhumb.Line(p1.lat, p1.lon, azi1);
+}
+
+void rhumbInterpolate_(Coord p1, Coord p2, double * flatCoords, int numPoints) {
+  double s12;
+  const RhumbLine line = getInverseRhumbLine(p1, p2, s12);
   double ds = s12 / (numPoints - 1);
-  double dontcare;
-  unsigned outmask = Rhumb::mask::LATITUDE | Rhumb::mask::LONGITUDE;
 
   for (int i = 0; i < numPoints; i++) {
-    line.GenPosition(i * ds, outmask, flatCoords[2 * i + 1], flatCoords[2 * i], dontcare);
+    line.Position(i * ds, flatCoords[2 * i + 1], flatCoords[2 * i]);
   }
 }
 
 void rhumbInterpolate(Coord p1, Coord p2, intptr_t ptr, int numPoints) {
   rhumbInterpolate_(p1, p2, reinterpret_cast<double *>(ptr), numPoints);
 }
+
+Coord rhumbMeridianIntersection(Coord p1, Coord p2, double meridian) {
+  ensureArgOrder(p1, p2, meridian);
+  const Rhumb& rhumb = Rhumb::WGS84();
+  double s12;
+  const RhumbLine line = getInverseRhumbLine(p1, p2, s12);
+  return meridianIntersection_(p1, p2, meridian, s12,
+      [line](double s12, double& lat, double& lon) {
+        line.Position(s12, lat, lon);
+      });
+};
+
 
 // coordinate conversion
 std::string toMGRS(Coord p) {
@@ -116,6 +194,9 @@ Coord toLonLat(std::string mgrs) {
   return Coord {lon, lat};
 };
 
+
+
+
 EMSCRIPTEN_BINDINGS(GeographicLib) {
   // map Coord struct to an array
   value_array<Coord>("Coord")
@@ -135,9 +216,11 @@ EMSCRIPTEN_BINDINGS(GeographicLib) {
   function("geodesicDirect", &geodesicDirect);
   function("geodesicInverse", &geodesicInverse);
   function("geodesicInterpolate", &geodesicInterpolate);
+  function("geodesicMeridianIntersection", &geodesicMeridianIntersection);
   function("rhumbDirect", &rhumbDirect);
   function("rhumbInverse", &rhumbInverse);
   function("rhumbInterpolate", &rhumbInterpolate);
+  function("rhumbMeridianIntersection", &rhumbMeridianIntersection);
   function("toMGRS", &toMGRS);
   function("toLonLat", &toLonLat);
 }

--- a/src/postfix.js
+++ b/src/postfix.js
@@ -61,11 +61,43 @@ var wrapSingle = function(func) {
     });
 };
 
+
+/**
+ * @param {function(Array<number>, Array<number>, number):*} func
+ * @return {function(Array<number>, Array<number>, number):*}
+ */
+var wrapIntersection = function(func) {
+  return (
+    /**
+     * @param {Array<number>} p1
+     * @param {Array<number>} p2
+     * @param {number} meridian
+     */
+    function(p1, p2, meridian) {
+      if (p1.length > 2) {
+        p1 = p1.slice(0, 2);
+      }
+
+      if (p2.length > 2) {
+        p2 = p2.slice(0, 2);
+      }
+
+      return func(p1, p2, meridian);
+    });
+};
+
 Module['postRun'] = [function() {
   Module['geodesicDirect'] = wrapDirect(Module['geodesicDirect']);
-  Module['rhumbDirect'] = wrapDirect(Module['rhumbDirect']);
   Module['geodesicInverse'] = wrapInverse(Module['geodesicInverse']);
+  Module['geodesicMeridianIntersection'] = wrapIntersection(Module['geodesicMeridianIntersection']);
+
+  Module['rhumbDirect'] = wrapDirect(Module['rhumbDirect']);
   Module['rhumbInverse'] = wrapInverse(Module['rhumbInverse']);
+  Module['rhumbMeridianIntersection'] = wrapIntersection(Module['rhumbMeridianIntersection']);
+
   Module['toMGRS'] = wrapSingle(Module['toMGRS']);
 }];
-window['osasm'] = Module;
+
+if (isBrowser()) {
+  window['osasm'] = Module;
+}

--- a/src/prefix.js
+++ b/src/prefix.js
@@ -1,39 +1,50 @@
 // get path to current script
-var script = document.currentScript;
-if (!script) {
-  var ss = document.getElementsByTagName('script');
-  var i=ss.length;
-  while(i--){
-    if(ss[i].src.indexOf('/os-load.js')>-1){
-      script=ss[i];
-      break;
+var isBrowser = function() {
+  try {
+    return this === window;
+  } catch (e) {
+  }
+  return false;
+};
+
+
+if (isBrowser()) {
+  var script = document.currentScript;
+  if (!script) {
+    var ss = document.getElementsByTagName('script');
+    var i=ss.length;
+    while(i--){
+      if(ss[i].src.indexOf('/os-load.js')>-1){
+        script=ss[i];
+        break;
+      }
     }
   }
+
+  var path = script.src;
+
+  var locateFile = function(url) {
+    if (url.indexOf('/') === -1) {
+      return path.replace(/(^.*)\/.*?$/, '$1/' + url);
+    }
+
+    return url;
+  };
+
+  var Module = {
+    'locateFile': locateFile,
+    'wasmBinaryFile': locateFile('os-wasm.wasm')
+  };
+
+  // fetch skips credentials by default, we want our wasm loader to use it
+  var origFetch = window.fetch;
+  var fetch = function(url, options) {
+    options = options || {};
+
+    if (!options.credentials) {
+      options.credentials = 'same-origin';
+    }
+
+    return origFetch(url, options);
+  };
 }
-
-var path = script.src;
-
-var locateFile = function(url) {
-  if (url.indexOf('/') === -1) {
-    return path.replace(/(^.*)\/.*?$/, '$1/' + url);
-  }
-
-  return url;
-};
-
-var Module = {
-  'locateFile': locateFile,
-  'wasmBinaryFile': locateFile('os-wasm.wasm')
-};
-
-// fetch skips credentials by default, we want our wasm loader to use it
-var origFetch = window.fetch;
-var fetch = function(url, options) {
-  options = options || {};
-
-  if (!options.credentials) {
-    options.credentials = 'same-origin';
-  }
-
-  return origFetch(url, options);
-};

--- a/test/geodesic.test.js
+++ b/test/geodesic.test.js
@@ -96,4 +96,29 @@ describe('geodesic', function() {
     }
     osasm._free(ptr);
   });
+
+  it('should find geodesic line intersection with a given meridian', function() {
+    const tests = [{
+      p1: [-5, 0, 15], p2: [4, 0, 12], m: 0,
+      expected: [0, 0]
+    }, {
+      p1: [178, 0, 15], p2: [-177, 0, 12], m: -180,
+      expected: [-180, 0]
+    }];
+
+    tests.forEach((test) => {
+      let result = osasm.geodesicMeridianIntersection(test.p1.slice(), test.p2.slice(), test.m);
+      expect(result[0]).toBeCloseTo(test.expected[0], 7);
+      expect(result[1]).toBe(test.expected[1]);
+
+      // flip the points around and run it again
+      const swp = test.p1;
+      test.p1 = test.p2;
+      test.p2 = swp;
+
+      result = osasm.geodesicMeridianIntersection(test.p1.slice(), test.p2.slice(), test.m);
+      expect(result[0]).toBeCloseTo(test.expected[0], 7);
+      expect(result[1]).toBe(test.expected[1]);
+    });
+  });
 });

--- a/test/rhumb.test.js
+++ b/test/rhumb.test.js
@@ -53,4 +53,28 @@ describe('rhumb', function() {
     osasm._free(ptr);
   });
 
+  it('should find rhumb line intersection with a given meridian', function() {
+    const tests = [{
+      p1: [-5, 0, 15], p2: [4, 0, 12], m: 0,
+      expected: [0, 0]
+    }, {
+      p1: [178, 0, 15], p2: [-177, 0, 12], m: -180,
+      expected: [-180, 0]
+    }];
+
+    tests.forEach((test) => {
+      let result = osasm.rhumbMeridianIntersection(test.p1.slice(), test.p2.slice(), test.m);
+      expect(result[0]).toBeCloseTo(test.expected[0], 7);
+      expect(result[1]).toBe(test.expected[1]);
+
+      // flip the points around and run it again
+      const swp = test.p1;
+      test.p1 = test.p2;
+      test.p2 = swp;
+
+      result = osasm.rhumbMeridianIntersection(test.p1.slice(), test.p2.slice(), test.m);
+      expect(result[0]).toBeCloseTo(test.expected[0], 7);
+      expect(result[1]).toBe(test.expected[1]);
+    });
+  });
 });


### PR DESCRIPTION
Adds support for loading in node (older node versions may need the `--experimental-modules` flag). Also adds support for determining the coordinate at which a geodesic or rhumb line intersects a given meridian.